### PR TITLE
Visibility option to wrap private methods

### DIFF
--- a/lib/trace_wrapper.rb
+++ b/lib/trace_wrapper.rb
@@ -65,7 +65,7 @@ class TraceWrapper
            method_type: :all,
            visibility: %i[public protected])
     unwrappers = []
-    [*receivers].each do |receiver|
+    Array(*receivers).each do |receiver|
       if %i[all self].include?(method_type)
         unwrappers += wrap_methods(receiver, visibility: visibility)
       end
@@ -96,7 +96,7 @@ class TraceWrapper
   # Wrap standard methods (methods on the object given) with tracing
   def wrap_methods(*receivers, visibility: %i[public protected])
     unwrappers = []
-    [*receivers].each do |receiver|
+    Array(*receivers).each do |receiver|
       mod, unwrapper = wrapping_module(receiver, :self, visibility)
       unwrappers << unwrapper
       receiver.singleton_class.send(:prepend, mod)
@@ -108,7 +108,7 @@ class TraceWrapper
   # tracing
   def wrap_instance_methods(*receivers, visibility: %i[public protected])
     unwrappers = []
-    [*receivers].each do |receiver|
+    Array(*receivers).each do |receiver|
       mod, unwrapper = wrapping_module(receiver, :instance, visibility)
       unwrappers << unwrapper
       receiver.send(:prepend, mod)

--- a/lib/trace_wrapper.rb
+++ b/lib/trace_wrapper.rb
@@ -56,16 +56,21 @@ class TraceWrapper
   #                :instance for methods on instances of receiver(s)
   #                :self for methods called directly on the receiver(s)
   #                :all for both
+  # :visibility - Array of method visibility levels to wrap. Can include
+  #               :public, :protected, :private
+  #               (default [:public, :protected])
   #
   # If a block is given, the wrappers will be created just around the block
-  def wrap(*receivers, method_type: :all)
+  def wrap(*receivers,
+           method_type: :all,
+           visibility: %i[public protected])
     unwrappers = []
     [*receivers].each do |receiver|
       if %i[all self].include?(method_type)
-        unwrappers += wrap_methods(receiver)
+        unwrappers += wrap_methods(receiver, visibility: visibility)
       end
       if %i[all instance].include?(method_type)
-        unwrappers += wrap_instance_methods(receiver)
+        unwrappers += wrap_instance_methods(receiver, visibility: visibility)
       end
     end
     if block_given?
@@ -89,10 +94,10 @@ class TraceWrapper
   private
 
   # Wrap standard methods (methods on the object given) with tracing
-  def wrap_methods(*receivers)
+  def wrap_methods(*receivers, visibility: %i[public protected])
     unwrappers = []
     [*receivers].each do |receiver|
-      mod, unwrapper = wrapping_module(receiver, :self)
+      mod, unwrapper = wrapping_module(receiver, :self, visibility)
       unwrappers << unwrapper
       receiver.singleton_class.send(:prepend, mod)
     end
@@ -101,18 +106,18 @@ class TraceWrapper
 
   # Wrap instance methods (called on an instance of the class given) with
   # tracing
-  def wrap_instance_methods(*receivers)
+  def wrap_instance_methods(*receivers, visibility: %i[public protected])
     unwrappers = []
     [*receivers].each do |receiver|
-      mod, unwrapper = wrapping_module(receiver, :instance)
+      mod, unwrapper = wrapping_module(receiver, :instance, visibility)
       unwrappers << unwrapper
       receiver.send(:prepend, mod)
     end
     unwrappers
   end
 
-  def wrapping_module(receiver, method_type)
-    method_names = get_methods(receiver, method_type)
+  def wrapping_module(receiver, method_type, visibility)
+    method_names = get_methods(receiver, method_type, visibility)
     get_method = method_type == :instance ? :instance_method : :method
     dot = method_type == :instance ? '#' : '.'
     trace_call = method(:trace_call)
@@ -148,9 +153,26 @@ class TraceWrapper
     [mod, unwrapper]
   end
 
-  def get_methods(receiver, method_type)
-    lister = method_type == :instance ? :instance_methods : :methods
-    receiver.public_send(lister, false) - Object.public_send(lister)
+  LIST_METHODS = {
+    instance: {
+      public: :public_instance_methods,
+      protected: :protected_instance_methods,
+      private: :private_instance_methods
+    },
+    self: {
+      public: :public_methods,
+      protected: :protected_methods,
+      private: :private_methods
+    }
+  }.freeze
+
+  def get_methods(receiver, method_type, visibility)
+    %i[public protected private].map do |vis|
+      next unless visibility.include?(vis)
+
+      lister = LIST_METHODS[method_type][vis]
+      receiver.public_send(lister, false) - Object.public_send(lister)
+    end.compact.flatten
   end
 
   def trace_call(receiver, dot, method_name, *args, **kwargs)

--- a/test/playground.rb
+++ b/test/playground.rb
@@ -22,6 +22,26 @@ class PlayClass
   def play(*args)
     args.map(&:to_s).join(', ')
   end
+
+  def play_friendly(*args)
+    friendly(*args)
+  end
+
+  def play_solitaire(*args)
+    solitaire(*args)
+  end
+
+  protected
+
+  def friendly(*args)
+    "friends: #{args.map(&:to_s).join(', ')}"
+  end
+
+  private
+
+  def solitaire(*args)
+    "solo: #{args.map(&:to_s).join(', ')}"
+  end
 end
 
 module PlayArgs

--- a/test/test_trace_wrapper.rb
+++ b/test/test_trace_wrapper.rb
@@ -77,7 +77,7 @@ class TestTraceWrapper < Minitest::Test
                    .gsub!('TWO', "#{TEAL}two#{CLEAR}")
 
     subject = lambda do |tracer|
-      tracer.wrap(PlayModule, method_type: :methods)
+      tracer.wrap(PlayModule, method_type: :self)
       result = PlayModule.two do
         PlayModule.one('abc')
       end
@@ -143,7 +143,7 @@ class TestTraceWrapper < Minitest::Test
                    .gsub!(/ARG\((\d+)\)/, "#{PURPLE}\\1#{CLEAR}")
 
     subject = lambda do |tracer|
-      tracer.wrap(PlayFib, method_type: :instance_methods)
+      tracer.wrap(PlayFib, method_type: :instance)
       result = PlayFib.new.fib(4)
 
       assert_equal(5, result)

--- a/test/test_trace_wrapper.rb
+++ b/test/test_trace_wrapper.rb
@@ -114,6 +114,58 @@ class TestTraceWrapper < Minitest::Test
     assert_equal_output(expected_output, colour: true, &subject)
   end
 
+  def test_wrap_output_protected_methods
+    cls_name = "#{B_GREEN}PlayClass#{CLEAR}"
+
+    expected_output = <<-OUTPUT.gsub(/^ {4}/, '')
+      CLASS#PLAY_FRIENDLY(@1@)
+        CLASS#FRIENDLY(@1@)
+        CLASS#FRIENDLY RETURN @"friends: 1"@
+      CLASS#PLAY_FRIENDLY RETURN @"friends: 1"@
+    OUTPUT
+    expected_output.gsub!('CLASS', cls_name)
+                   .gsub!('RETURN', RETURN)
+                   .gsub!('PLAY_FRIENDLY', "#{TEAL}play_friendly#{CLEAR}")
+                   .gsub!('FRIENDLY', "#{TEAL}friendly#{CLEAR}")
+                   .gsub!(/@([^@]*)@/, "#{PURPLE}\\1#{CLEAR}")
+
+    subject = lambda do |tracer|
+      tracer.wrap(PlayClass)
+      result = PlayClass.new.play_friendly(1)
+
+      assert_equal('friends: 1', result)
+    end
+
+    assert_equal_output(strip_colour(expected_output), colour: false, &subject)
+    assert_equal_output(expected_output, colour: true, &subject)
+  end
+
+  def test_wrap_output_private_methods
+    cls_name = "#{B_GREEN}PlayClass#{CLEAR}"
+
+    expected_output = <<-OUTPUT.gsub(/^ {4}/, '')
+      CLASS#PLAY_SOLITAIRE(@2@, @3@)
+        CLASS#SOLITAIRE(@2@, @3@)
+        CLASS#SOLITAIRE RETURN @"solo: 2, 3"@
+      CLASS#PLAY_SOLITAIRE RETURN @"solo: 2, 3"@
+    OUTPUT
+    expected_output.gsub!('CLASS', cls_name)
+                   .gsub!('RETURN', RETURN)
+                   .gsub!('PLAY_SOLITAIRE', "#{TEAL}play_solitaire#{CLEAR}")
+                   .gsub!('SOLITAIRE', "#{TEAL}solitaire#{CLEAR}")
+                   .gsub!(/@([^@]*)@/, "#{PURPLE}\\1#{CLEAR}")
+
+    subject = lambda do |tracer|
+      tracer.wrap(PlayClass, visibility: %i[public protected private])
+      result = PlayClass.new.play_solitaire(2, 3)
+
+      assert_equal('solo: 2, 3', result)
+    end
+
+    assert_equal_output(strip_colour(expected_output), colour: false, &subject)
+    assert_equal_output(expected_output, colour: true, &subject)
+  end
+
   def test_wrap_output_class_nesting
     cls_name = "#{B_GREEN}PlayFib#{CLEAR}"
     fib = "#{TEAL}fib#{CLEAR}"


### PR DESCRIPTION
* Adds `:visibility` option to `wrap` (defaults to `%i[public protected]`). Set this to `%i[public protected private]` to include private methods too.
* Changes `:method_type` options to:
  * `:instance` to wrap instance methods of receiver(s)
  * `:self` to wrap methods directly on the receiver(s) (i.e. class methods if the receiver is a class)
  * `:all` to wrap instance and direct methods
* Add ability to pass receivers as an array to wrap